### PR TITLE
Change of deprecated np.infty

### DIFF
--- a/odeformer/metrics.py
+++ b/odeformer/metrics.py
@@ -219,7 +219,7 @@ def compute_metrics(predicted, true, predicted_tree=None, tree=None, metrics="r2
                 else:
                     try:
                         l1_error = np.mean(np.abs((true[i] - predicted[i])))
-                        if np.isnan(l1_error): results[metric].append(np.infty)
+                        if np.isnan(l1_error): results[metric].append(np.inf)
                         else: results[metric].append(l1_error)
                     except Exception as e:
                         results[metric].append(np.nan)

--- a/odeformer/model/mixins.py
+++ b/odeformer/model/mixins.py
@@ -117,7 +117,7 @@ class GridSearchMixin(ABC):
                 metrics = sorting_metric,
             )[sorting_metric][0]
             if math.isnan(_score): 
-                _score = -np.infty if descending else np.infty
+                _score = -np.inf if descending else np.inf
             _scores.append(_score)
         sorted_idx = np.argsort(_scores)  
         if descending: sorted_idx = list(reversed(sorted_idx))

--- a/odeformer/model/sklearn_wrapper.py
+++ b/odeformer/model/sklearn_wrapper.py
@@ -211,7 +211,7 @@ class SymbolicTransformerRegressor(BaseEstimator, PredictionIntegrationMixin):
         for candidate in candidates:
             score = self.evaluate_tree(candidate, times, trajectory, metric)
             if math.isnan(score): 
-                score = -np.infty if descending else np.infty
+                score = -np.inf if descending else np.inf
             scores.append(score)
         sorted_idx = np.argsort(scores)  
 

--- a/odeformer/regressors.py
+++ b/odeformer/regressors.py
@@ -21,7 +21,7 @@ def order_data(X, y):
 
 def get_infinite_relative_error(prediction, truth):
     abs_relative_error = np.abs((prediction - truth) / (truth + 1e-100))
-    abs_relative_error = np.nan_to_num(abs_relative_error, nan=np.infty)
+    abs_relative_error = np.nan_to_num(abs_relative_error, nan=np.inf)
     return np.max(abs_relative_error)
 
 

--- a/odeformer/trainer.py
+++ b/odeformer/trainer.py
@@ -170,7 +170,7 @@ class Trainer(object):
             m = (m, True) if 'r2' in m else (m, False)
             self.metrics.append(m)
         self.best_metrics = {
-            metric: (-np.infty if biggest else np.infty)
+            metric: (-np.inf if biggest else np.inf)
             for (metric, biggest) in self.metrics
         }
 


### PR DESCRIPTION
`np.infty` has been [deprecated in NumPy 2.0](https://numpy.org/devdocs/numpy_2_0_migration_guide.html), so when using NumPy >=2.0 there will be errors. For me it happens in the following code block in your examply Jupyter Notebook, where the results of Figure 1 are reproduced. 
```python
for equation in equations:
    plot_prediction(dstr, equation, seed=0, noise=.05, subsampling=.5)
```

This PR is a simple find-and-replace which fixes the issue.